### PR TITLE
Fixes typo in example code in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ type AddInput struct {
 	B int `json:"b"`
 }
 
-func (m *Math) Add(in *AddInput) (interface{}, error) {
+func (m *Math) Add(in *AddInput) (int, error) {
 	return in.A + in.B, nil
 }
 


### PR DESCRIPTION
Hi,

just a small typo I found in the example code of the README, while reading through the code.
I think the first argument of the `Add` function is supposed to be an `int`.

Thank you for this lib!

Cheers,
Christian
